### PR TITLE
FEAT: Windows Theme & Dark Mode Support

### DIFF
--- a/win-gui/About.cs
+++ b/win-gui/About.cs
@@ -8,6 +8,7 @@ namespace Synthesia
       public About()
       {
          InitializeComponent();
+         ThemeManager.ApplyThemeFromSettings(this);
          Text = $"About {AssemblyTitle}";
          labelProductName.Text = AssemblyProduct;
          labelCopyright.Text = AssemblyCopyright;

--- a/win-gui/GroupEditor.cs
+++ b/win-gui/GroupEditor.cs
@@ -40,6 +40,7 @@ namespace Synthesia
          MadeChanges = false;
          Metadata = metadata;
          InitializeComponent();
+         ThemeManager.ApplyThemeFromSettings(this);
 
          List<SongEntry> remainingSongs = Metadata.Songs.ToList();
          foreach (GroupEntry g in Metadata.Groups) PopulateGroup(null, g, remainingSongs);

--- a/win-gui/ImportSelection.cs
+++ b/win-gui/ImportSelection.cs
@@ -15,6 +15,7 @@ namespace Synthesia
       public ImportSelection()
       {
          InitializeComponent();
+         ThemeManager.ApplyThemeFromSettings(this);
       }
 
       private void CheckChanged(object sender, EventArgs e)

--- a/win-gui/MetadataEditor.Designer.cs
+++ b/win-gui/MetadataEditor.Designer.cs
@@ -65,6 +65,11 @@
 			this.ImportMenu = new System.Windows.Forms.ToolStripMenuItem();
 			this.toolStripMenuItem2 = new System.Windows.Forms.ToolStripSeparator();
 			this.ExitMenu = new System.Windows.Forms.ToolStripMenuItem();
+			this.ViewMenu = new System.Windows.Forms.ToolStripMenuItem();
+			this.ThemeMenu = new System.Windows.Forms.ToolStripMenuItem();
+			this.ThemeSystemMenu = new System.Windows.Forms.ToolStripMenuItem();
+			this.ThemeLightMenu = new System.Windows.Forms.ToolStripMenuItem();
+			this.ThemeDarkMenu = new System.Windows.Forms.ToolStripMenuItem();
 			this.HelpMenu = new System.Windows.Forms.ToolStripMenuItem();
 			this.AboutMenu = new System.Windows.Forms.ToolStripMenuItem();
 			this.Tip = new System.Windows.Forms.ToolTip(this.components);
@@ -362,6 +367,7 @@
 			// 
 			this.MainMenu.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.FileMenu,
+            this.ViewMenu,
             this.HelpMenu});
 			this.MainMenu.Location = new System.Drawing.Point(0, 0);
 			this.MainMenu.Name = "MainMenu";
@@ -438,6 +444,45 @@
 			this.ExitMenu.Size = new System.Drawing.Size(227, 22);
 			this.ExitMenu.Text = "E&xit";
 			this.ExitMenu.Click += new System.EventHandler(this.ExitMenu_Click);
+			// 
+			// ViewMenu
+			// 
+			this.ViewMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.ThemeMenu});
+			this.ViewMenu.Name = "ViewMenu";
+			this.ViewMenu.Size = new System.Drawing.Size(44, 20);
+			this.ViewMenu.Text = "&View";
+			// 
+			// ThemeMenu
+			// 
+			this.ThemeMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.ThemeSystemMenu,
+            this.ThemeLightMenu,
+            this.ThemeDarkMenu});
+			this.ThemeMenu.Name = "ThemeMenu";
+			this.ThemeMenu.Size = new System.Drawing.Size(113, 22);
+			this.ThemeMenu.Text = "&Theme";
+			// 
+			// ThemeSystemMenu
+			// 
+			this.ThemeSystemMenu.Name = "ThemeSystemMenu";
+			this.ThemeSystemMenu.Size = new System.Drawing.Size(170, 22);
+			this.ThemeSystemMenu.Text = "&Auto Detect System (Default)";
+			this.ThemeSystemMenu.Click += new System.EventHandler(this.ThemeSystemMenu_Click);
+			// 
+			// ThemeLightMenu
+			// 
+			this.ThemeLightMenu.Name = "ThemeLightMenu";
+			this.ThemeLightMenu.Size = new System.Drawing.Size(170, 22);
+			this.ThemeLightMenu.Text = "&Light";
+			this.ThemeLightMenu.Click += new System.EventHandler(this.ThemeLightMenu_Click);
+			// 
+			// ThemeDarkMenu
+			// 
+			this.ThemeDarkMenu.Name = "ThemeDarkMenu";
+			this.ThemeDarkMenu.Size = new System.Drawing.Size(170, 22);
+			this.ThemeDarkMenu.Text = "&Dark";
+			this.ThemeDarkMenu.Click += new System.EventHandler(this.ThemeDarkMenu_Click);
 			// 
 			// HelpMenu
 			// 
@@ -838,6 +883,11 @@
         private System.Windows.Forms.ToolStripMenuItem SaveAsMenu;
         private System.Windows.Forms.ToolStripSeparator toolStripMenuItem1;
         private System.Windows.Forms.ToolStripMenuItem ExitMenu;
+        private System.Windows.Forms.ToolStripMenuItem ViewMenu;
+        private System.Windows.Forms.ToolStripMenuItem ThemeMenu;
+        private System.Windows.Forms.ToolStripMenuItem ThemeSystemMenu;
+        private System.Windows.Forms.ToolStripMenuItem ThemeLightMenu;
+        private System.Windows.Forms.ToolStripMenuItem ThemeDarkMenu;
         private System.Windows.Forms.ToolStripMenuItem HelpMenu;
         private System.Windows.Forms.ToolStripMenuItem AboutMenu;
         private System.Windows.Forms.ToolTip Tip;

--- a/win-gui/MetadataEditor.cs
+++ b/win-gui/MetadataEditor.cs
@@ -11,6 +11,9 @@ namespace Synthesia
 {
    public partial class MetadataEditor : Form, IGuiForm
    {
+      private bool _handlingThemeChange;
+      private bool _propertiesEnabled;
+
       [Browsable(false)]
       [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
       public GuiController c { get; set; }
@@ -92,7 +95,10 @@ namespace Synthesia
 
       private void RemoveSong_Click(object sender, EventArgs e) { c.RemoveSelectedSongs(); }
       private void SongGrouping_Click(object sender, EventArgs e) { c.Grouping(); }
-      private void Md5Update_Click(object sender, EventArgs e) { c.RetargetUniqueId(); }
+      private void Md5Update_Click(object sender, EventArgs e)
+      {
+         c.RetargetUniqueId();
+      }
       private void AddSong_Click(object sender, EventArgs e)
       {
          if (OpenSongDialog.ShowDialog(this) != DialogResult.OK) return;
@@ -213,8 +219,6 @@ namespace Synthesia
          SortedDictionary<string, int> tagFrequency = new SortedDictionary<string, int>();
          Dictionary<KeyValuePair<int, string>, int> bookmarkFrequency = new Dictionary<KeyValuePair<int, string>, int>();
 
-         Md5Update.Enabled = selectedCount == 1;
-
          foreach (SongEntry e in SelectedSongs)
          {
             foreach (string tag in e.Tags) tagFrequency[tag] = tagFrequency.ContainsKey(tag) ? tagFrequency[tag] + 1 : 1;
@@ -230,6 +234,7 @@ namespace Synthesia
 
       private void SetPropertiesEnabled(bool enabled)
       {
+         _propertiesEnabled = enabled;
          // Keep the group and labels enabled for legible text; disable inputs/actions only.
          PropertiesGroup.Enabled = true;
 
@@ -261,6 +266,10 @@ namespace Synthesia
          AddBookmark.Enabled = enabled;
          RemoveBookmark.Enabled = enabled && BookmarkList.SelectedIndex != -1;
          Md5Update.Enabled = enabled && SongList.SelectedItems.Count == 1;
+
+         var mode = ThemeManager.GetEffectiveThemeMode(ThemeManager.GetUserThemeMode());
+         ThemeManager.ApplyTheme(BackgroundBrowse, mode);
+         ThemeManager.ApplyTheme(Md5Update, mode);
       }
 
       private void AddTag_Click(object sender, EventArgs e)

--- a/win-gui/MetadataEditor.cs
+++ b/win-gui/MetadataEditor.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Drawing;
+using System.ComponentModel;
+using Microsoft.Win32;
 using System.Linq;
 using System.Reflection;
 using System.Windows.Forms;
@@ -9,6 +11,8 @@ namespace Synthesia
 {
    public partial class MetadataEditor : Form, IGuiForm
    {
+      [Browsable(false)]
+      [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
       public GuiController c { get; set; }
 
       public IEnumerable<SongEntry> SelectedSongs => from s in SongList.SelectedItems.Cast<SongEntry>() select s;
@@ -40,6 +44,9 @@ namespace Synthesia
       public MetadataEditor(string initialFile)
       {
          InitializeComponent();
+         ApplyThemeFromSettings();
+         SystemEvents.UserPreferenceChanged += SystemEvents_UserPreferenceChanged;
+         FormClosed += MetadataEditor_FormClosed;
 
          // NOTE: This c.set is actually superfluous.  The GuiController sets it for us.
          c = new GuiController(this, initialFile);
@@ -55,6 +62,11 @@ namespace Synthesia
          Icon = Icon.ExtractAssociatedIcon(Application.ExecutablePath);
       }
 
+      private void MetadataEditor_FormClosed(object sender, FormClosedEventArgs e)
+      {
+         SystemEvents.UserPreferenceChanged -= SystemEvents_UserPreferenceChanged;
+      }
+
       private void NewMenu_Click(object sender, EventArgs e) { c.CreateNew(); }
       private void OpenMenu_Click(object sender, EventArgs e) { c.Open(); }
       private void SaveMenu_Click(object sender, EventArgs e) { c.SaveChanges(); }
@@ -62,6 +74,21 @@ namespace Synthesia
       private void ImportMenu_Click(object sender, EventArgs e) { c.Import(); }
       private void AboutMenu_Click(object sender, EventArgs e) { new About().ShowDialog(); }
       private void ExitMenu_Click(object sender, EventArgs e) { Close(); }
+
+      private void ThemeSystemMenu_Click(object sender, EventArgs e)
+      {
+         SetThemeMode(ThemeMode.System);
+      }
+
+      private void ThemeLightMenu_Click(object sender, EventArgs e)
+      {
+         SetThemeMode(ThemeMode.Light);
+      }
+
+      private void ThemeDarkMenu_Click(object sender, EventArgs e)
+      {
+         SetThemeMode(ThemeMode.Dark);
+      }
 
       private void RemoveSong_Click(object sender, EventArgs e) { c.RemoveSelectedSongs(); }
       private void SongGrouping_Click(object sender, EventArgs e) { c.Grouping(); }
@@ -305,6 +332,44 @@ namespace Synthesia
       {
          var relative = c.BrowseBackground();
          if (relative != null) BackgroundBox.Text = relative;
+      }
+
+      private void ApplyThemeFromSettings()
+      {
+         ThemeManager.ApplyThemeFromSettings(this);
+         UpdateThemeMenuState();
+      }
+
+      private void UpdateThemeMenuState()
+      {
+         ThemeMode userMode = ThemeManager.GetUserThemeMode();
+         ThemeSystemMenu.Checked = userMode == ThemeMode.System;
+         ThemeLightMenu.Checked = userMode == ThemeMode.Light;
+         ThemeDarkMenu.Checked = userMode == ThemeMode.Dark;
+      }
+
+      private void SetThemeMode(ThemeMode mode)
+      {
+         if (_handlingThemeChange) return;
+
+         try
+         {
+            _handlingThemeChange = true;
+            ThemeManager.SetUserThemeMode(mode);
+            ApplyThemeFromSettings();
+         }
+         finally
+         {
+            _handlingThemeChange = false;
+         }
+      }
+
+      private void SystemEvents_UserPreferenceChanged(object sender, UserPreferenceChangedEventArgs e)
+      {
+         if (!IsHandleCreated) return;
+         if (ThemeManager.GetUserThemeMode() != ThemeMode.System) return;
+
+         BeginInvoke((Action)(() => ApplyThemeFromSettings()));
       }
    }
 }

--- a/win-gui/MetadataEditor.cs
+++ b/win-gui/MetadataEditor.cs
@@ -122,39 +122,59 @@ namespace Synthesia
 
       public void ClearSongControls()
       {
+         var primaryText = ThemeManager.GetPrimaryTextColor();
+         var mutedText = ThemeManager.GetMutedTextColor();
+
          UniqueIdBox.Text = "(No song selected)";
+         UniqueIdBox.ForeColor = mutedText;
          TitleBox.Clear();
+         TitleBox.ForeColor = primaryText;
          SubtitleBox.Clear();
+         SubtitleBox.ForeColor = primaryText;
 
          BackgroundBox.Clear();
+         BackgroundBox.ForeColor = primaryText;
 
          ComposerBox.Clear();
+         ComposerBox.ForeColor = primaryText;
          ArrangerBox.Clear();
+         ArrangerBox.ForeColor = primaryText;
          CopyrightBox.Clear();
+         CopyrightBox.ForeColor = primaryText;
          LicenseBox.Clear();
+         LicenseBox.ForeColor = primaryText;
          MadeFamousByBox.Clear();
+         MadeFamousByBox.ForeColor = primaryText;
 
          DifficultyBox.Value = 0;
+         DifficultyBox.ForeColor = primaryText;
          RatingBox.Value = 0;
+         RatingBox.ForeColor = primaryText;
 
          FingerHintBox.Clear();
+         FingerHintBox.ForeColor = primaryText;
          HandsBox.Clear();
+         HandsBox.ForeColor = primaryText;
+         PartsBox.ForeColor = primaryText;
 
          TagBox.Clear();
+         TagBox.ForeColor = primaryText;
          TagList.Items.Clear();
 
          BookmarkMeasureBox.Value = 1;
+         BookmarkMeasureBox.ForeColor = primaryText;
          BookmarkDescriptionBox.Clear();
+         BookmarkDescriptionBox.ForeColor = primaryText;
          BookmarkList.Items.Clear();
 
-         PropertiesGroup.Enabled = false;
+         SetPropertiesEnabled(false);
       }
 
       private void BindBox(TextBox box, PropertyInfo prop)
       {
          int values = (from e in SelectedSongs select prop.GetValue(e, null) as string).Distinct().Count();
 
-         box.ForeColor = values == 1 ? SystemColors.ControlText : SystemColors.GrayText;
+         box.ForeColor = values == 1 ? ThemeManager.GetPrimaryTextColor() : ThemeManager.GetMutedTextColor();
          box.Text = values == 1 ? prop.GetValue(SelectedSongs.First(), null) as string : "(Various)";
       }
 
@@ -162,13 +182,13 @@ namespace Synthesia
       {
          int values = (from e in SelectedSongs select prop.GetValue(e, null) as int?).Distinct().Count();
 
-         box.ForeColor = values == 1 ? SystemColors.ControlText : SystemColors.GrayText;
+         box.ForeColor = values == 1 ? ThemeManager.GetPrimaryTextColor() : ThemeManager.GetMutedTextColor();
          box.Value = values == 1 ? (prop.GetValue(SelectedSongs.First(), null) as int?) ?? 0 : 0;
       }
 
       public void BindSongControls()
       {
-         PropertiesGroup.Enabled = true;
+         SetPropertiesEnabled(true);
 
          BindBox(UniqueIdBox, typeof(SongEntry).GetProperty("UniqueId"));
          BindBox(TitleBox, typeof(SongEntry).GetProperty("Title"));
@@ -206,6 +226,41 @@ namespace Synthesia
 
          BookmarkList.Items.Clear();
          foreach (var b in bookmarkFrequency) if (b.Value == selectedCount) BookmarkList.Items.Add(new Bookmark(b.Key.Key, b.Key.Value));
+      }
+
+      private void SetPropertiesEnabled(bool enabled)
+      {
+         // Keep the group and labels enabled for legible text; disable inputs/actions only.
+         PropertiesGroup.Enabled = true;
+
+         // NOTE: Keep the labels readable while still disabling inputs when no song is selected. In WinForms, disabling
+         //       the GroupBox disables all child controls and forces them into a “disabled” color which is too dark for
+         //       readable contrast.
+         UniqueIdBox.Enabled = enabled;
+         TitleBox.Enabled = enabled;
+         SubtitleBox.Enabled = enabled;
+         BackgroundBox.Enabled = enabled;
+         BackgroundBrowse.Enabled = enabled;
+         ComposerBox.Enabled = enabled;
+         ArrangerBox.Enabled = enabled;
+         CopyrightBox.Enabled = enabled;
+         LicenseBox.Enabled = enabled;
+         MadeFamousByBox.Enabled = enabled;
+         DifficultyBox.Enabled = enabled;
+         RatingBox.Enabled = enabled;
+         FingerHintBox.Enabled = enabled;
+         PartsBox.Enabled = enabled;
+         HandsBox.Enabled = enabled;
+         TagBox.Enabled = enabled;
+         TagList.Enabled = enabled;
+         AddTag.Enabled = enabled && TagBox.Text.Length > 0 && !TagList.Items.Contains(TagBox.Text);
+         RemoveTag.Enabled = enabled && TagList.SelectedIndex != -1;
+         BookmarkMeasureBox.Enabled = enabled;
+         BookmarkDescriptionBox.Enabled = enabled;
+         BookmarkList.Enabled = enabled;
+         AddBookmark.Enabled = enabled;
+         RemoveBookmark.Enabled = enabled && BookmarkList.SelectedIndex != -1;
+         Md5Update.Enabled = enabled && SongList.SelectedItems.Count == 1;
       }
 
       private void AddTag_Click(object sender, EventArgs e)

--- a/win-gui/Properties/Settings.Designer.cs
+++ b/win-gui/Properties/Settings.Designer.cs
@@ -22,5 +22,17 @@ namespace Synthesia.Properties {
                 return defaultInstance;
             }
         }
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("System")]
+        public string ThemeMode {
+            get {
+                return ((string)(this["ThemeMode"]));
+            }
+            set {
+                this["ThemeMode"] = value;
+            }
+        }
     }
 }

--- a/win-gui/Properties/Settings.settings
+++ b/win-gui/Properties/Settings.settings
@@ -3,5 +3,9 @@
   <Profiles>
     <Profile Name="(Default)" />
   </Profiles>
-  <Settings />
+  <Settings>
+    <Setting Name="ThemeMode" Type="System.String" Scope="User">
+      <Value Profile="(Default)">System</Value>
+    </Setting>
+  </Settings>
 </SettingsFile>

--- a/win-gui/SynthesiaMetadataGui.csproj
+++ b/win-gui/SynthesiaMetadataGui.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>

--- a/win-gui/ThemeManager.cs
+++ b/win-gui/ThemeManager.cs
@@ -1,0 +1,244 @@
+using System;
+using System.Drawing;
+using System.Windows.Forms;
+using Microsoft.Win32;
+using Synthesia.Properties;
+
+namespace Synthesia
+{
+   internal enum ThemeMode
+   {
+      System,
+      Light,
+      Dark
+   }
+
+   internal static class ThemeManager
+   {
+      private static readonly Color DarkBackground = Color.FromArgb(30, 30, 30);
+      private static readonly Color DarkSurface = Color.FromArgb(45, 45, 45);
+      private static readonly Color DarkBorder = Color.FromArgb(70, 70, 70);
+      private static readonly Color DarkText = Color.Gainsboro;
+
+      public static ThemeMode GetUserThemeMode()
+      {
+         if (Enum.TryParse(Settings.Default.ThemeMode, out ThemeMode mode)) return mode;
+         return ThemeMode.System;
+      }
+
+      public static void SetUserThemeMode(ThemeMode mode)
+      {
+         Settings.Default.ThemeMode = mode.ToString();
+         Settings.Default.Save();
+      }
+
+      public static ThemeMode GetEffectiveThemeMode(ThemeMode userMode)
+      {
+         if (userMode == ThemeMode.System) return IsSystemDarkMode() ? ThemeMode.Dark : ThemeMode.Light;
+         return userMode;
+      }
+
+      public static bool IsSystemDarkMode()
+      {
+         try
+         {
+            using (RegistryKey key = Registry.CurrentUser.OpenSubKey(@"Software\Microsoft\Windows\CurrentVersion\Themes\Personalize"))
+            {
+               object value = key?.GetValue("AppsUseLightTheme");
+               if (value is int intValue) return intValue == 0;
+            }
+         }
+         catch
+         {
+         }
+
+         return false;
+      }
+
+      public static void ApplyThemeFromSettings(Control root)
+      {
+         ThemeMode userMode = GetUserThemeMode();
+         ThemeMode mode = GetEffectiveThemeMode(userMode);
+         ApplyTheme(root, mode);
+      }
+
+      public static void ApplyTheme(Control root, ThemeMode mode)
+      {
+         if (root == null) return;
+
+         root.SuspendLayout();
+         if (mode == ThemeMode.Dark)
+         {
+            ApplyDarkTheme(root);
+         }
+         else
+         {
+            ApplyLightTheme(root);
+         }
+         root.ResumeLayout(true);
+      }
+
+      private static void ApplyDarkTheme(Control root)
+      {
+         ApplyDarkThemeToControl(root);
+      }
+
+      private static void ApplyLightTheme(Control root)
+      {
+         ApplyLightThemeToControl(root);
+      }
+
+      private static void ApplyDarkThemeToControl(Control control)
+      {
+         if (control is Form)
+         {
+            control.BackColor = DarkBackground;
+            control.ForeColor = DarkText;
+         }
+         else if (control is GroupBox)
+         {
+            control.BackColor = DarkBackground;
+            control.ForeColor = DarkText;
+         }
+         else if (control is MenuStrip menuStrip)
+         {
+            menuStrip.BackColor = DarkSurface;
+            menuStrip.ForeColor = DarkText;
+            ApplyDarkThemeToToolStripItems(menuStrip.Items);
+         }
+         else if (control is ToolStrip toolStrip)
+         {
+            toolStrip.BackColor = DarkSurface;
+            toolStrip.ForeColor = DarkText;
+            ApplyDarkThemeToToolStripItems(toolStrip.Items);
+         }
+         else if (control is TextBoxBase || control is ComboBox || control is ListBox)
+         {
+            control.BackColor = DarkBackground;
+            control.ForeColor = DarkText;
+         }
+         else if (control is NumericUpDown numericUpDown)
+         {
+            numericUpDown.BackColor = DarkBackground;
+            numericUpDown.ForeColor = DarkText;
+         }
+         else if (control is TreeView treeView)
+         {
+            treeView.BackColor = DarkBackground;
+            treeView.ForeColor = DarkText;
+         }
+         else if (control is Button button)
+         {
+            button.BackColor = DarkSurface;
+            button.ForeColor = DarkText;
+            button.FlatStyle = FlatStyle.Flat;
+            button.FlatAppearance.BorderColor = DarkBorder;
+         }
+         else if (control is Label || control is CheckBox || control is RadioButton)
+         {
+            control.ForeColor = DarkText;
+            control.BackColor = DarkBackground;
+         }
+         else
+         {
+            control.BackColor = DarkBackground;
+            control.ForeColor = DarkText;
+         }
+
+         foreach (Control child in control.Controls)
+         {
+            ApplyDarkThemeToControl(child);
+         }
+      }
+
+      private static void ApplyLightThemeToControl(Control control)
+      {
+         if (control is Form)
+         {
+            control.BackColor = SystemColors.Control;
+            control.ForeColor = SystemColors.ControlText;
+         }
+         else if (control is GroupBox)
+         {
+            control.BackColor = SystemColors.Control;
+            control.ForeColor = SystemColors.ControlText;
+         }
+         else if (control is MenuStrip menuStrip)
+         {
+            menuStrip.BackColor = SystemColors.Control;
+            menuStrip.ForeColor = SystemColors.ControlText;
+            ApplyLightThemeToToolStripItems(menuStrip.Items);
+         }
+         else if (control is ToolStrip toolStrip)
+         {
+            toolStrip.BackColor = SystemColors.Control;
+            toolStrip.ForeColor = SystemColors.ControlText;
+            ApplyLightThemeToToolStripItems(toolStrip.Items);
+         }
+         else if (control is TextBoxBase || control is ComboBox || control is ListBox)
+         {
+            control.BackColor = SystemColors.Window;
+            control.ForeColor = SystemColors.WindowText;
+         }
+         else if (control is NumericUpDown numericUpDown)
+         {
+            numericUpDown.BackColor = SystemColors.Window;
+            numericUpDown.ForeColor = SystemColors.WindowText;
+         }
+         else if (control is TreeView treeView)
+         {
+            treeView.BackColor = SystemColors.Window;
+            treeView.ForeColor = SystemColors.WindowText;
+         }
+         else if (control is Button button)
+         {
+            button.UseVisualStyleBackColor = true;
+            button.FlatStyle = FlatStyle.Standard;
+            button.ForeColor = SystemColors.ControlText;
+         }
+         else if (control is Label || control is CheckBox || control is RadioButton)
+         {
+            control.ForeColor = SystemColors.ControlText;
+            control.BackColor = SystemColors.Control;
+         }
+         else
+         {
+            control.BackColor = SystemColors.Control;
+            control.ForeColor = SystemColors.ControlText;
+         }
+
+         foreach (Control child in control.Controls)
+         {
+            ApplyLightThemeToControl(child);
+         }
+      }
+
+      private static void ApplyDarkThemeToToolStripItems(ToolStripItemCollection items)
+      {
+         foreach (ToolStripItem item in items)
+         {
+            item.ForeColor = DarkText;
+            if (item is ToolStripDropDownItem dropDownItem && dropDownItem.DropDown is ToolStripDropDownMenu menu)
+            {
+               menu.BackColor = DarkSurface;
+               menu.ForeColor = DarkText;
+               ApplyDarkThemeToToolStripItems(dropDownItem.DropDownItems);
+            }
+         }
+      }
+
+      private static void ApplyLightThemeToToolStripItems(ToolStripItemCollection items)
+      {
+         foreach (ToolStripItem item in items)
+         {
+            item.ForeColor = SystemColors.ControlText;
+            if (item is ToolStripDropDownItem dropDownItem && dropDownItem.DropDown is ToolStripDropDownMenu menu)
+            {
+               menu.BackColor = SystemColors.Control;
+               menu.ForeColor = SystemColors.ControlText;
+               ApplyLightThemeToToolStripItems(dropDownItem.DropDownItems);
+            }
+         }
+      }
+   }
+}

--- a/win-gui/ThemeManager.cs
+++ b/win-gui/ThemeManager.cs
@@ -42,6 +42,18 @@ namespace Synthesia
          return userMode;
       }
 
+      public static Color GetPrimaryTextColor()
+      {
+         ThemeMode mode = GetEffectiveThemeMode(GetUserThemeMode());
+         return mode == ThemeMode.Dark ? DarkText : SystemColors.ControlText;
+      }
+
+      public static Color GetMutedTextColor()
+      {
+         ThemeMode mode = GetEffectiveThemeMode(GetUserThemeMode());
+         return mode == ThemeMode.Dark ? DarkDisabledText : SystemColors.GrayText;
+      }
+
       public static bool IsSystemDarkMode()
       {
          try

--- a/win-gui/ThemeManager.cs
+++ b/win-gui/ThemeManager.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Drawing;
+using System.Runtime.InteropServices;
 using System.Windows.Forms;
 using Microsoft.Win32;
 using Synthesia.Properties;
@@ -84,6 +85,10 @@ namespace Synthesia
          if (root == null) return;
 
          root.SuspendLayout();
+         if (root is Form form)
+         {
+            ApplyWindowChromeTheme(form, mode);
+         }
          if (mode == ThemeMode.Dark)
          {
             ApplyDarkTheme(root);
@@ -94,6 +99,43 @@ namespace Synthesia
          }
          root.ResumeLayout(true);
       }
+
+      private static void ApplyWindowChromeTheme(Form form, ThemeMode mode)
+      {
+         if (!IsWindows10OrGreater()) return;
+
+         try
+         {
+            int useDark = mode == ThemeMode.Dark ? 1 : 0;
+            // Prefer the newer attribute on newer Windows, fallback to the older one.
+            if (DwmSetWindowAttribute(form.Handle, DWMWA_USE_IMMERSIVE_DARK_MODE, ref useDark, sizeof(int)) != 0)
+            {
+               DwmSetWindowAttribute(form.Handle, DWMWA_USE_IMMERSIVE_DARK_MODE_BEFORE_20H1, ref useDark, sizeof(int));
+            }
+         }
+         catch
+         {
+         }
+      }
+
+      private static bool IsWindows10OrGreater()
+      {
+         try
+         {
+            Version version = Environment.OSVersion.Version;
+            return version.Major >= 10;
+         }
+         catch
+         {
+            return false;
+         }
+      }
+
+      private const int DWMWA_USE_IMMERSIVE_DARK_MODE_BEFORE_20H1 = 19;
+      private const int DWMWA_USE_IMMERSIVE_DARK_MODE = 20;
+
+      [DllImport("dwmapi.dll")]
+      private static extern int DwmSetWindowAttribute(IntPtr hwnd, int attr, ref int attrValue, int attrSize);
 
       private static void ApplyDarkTheme(Control root)
       {

--- a/win-gui/ThemeManager.cs
+++ b/win-gui/ThemeManager.cs
@@ -18,7 +18,11 @@ namespace Synthesia
       private static readonly Color DarkBackground = Color.FromArgb(30, 30, 30);
       private static readonly Color DarkSurface = Color.FromArgb(45, 45, 45);
       private static readonly Color DarkBorder = Color.FromArgb(70, 70, 70);
+      private static readonly Color DarkHover = Color.FromArgb(60, 60, 60);
+      private static readonly Color DarkPressed = Color.FromArgb(80, 80, 80);
+      private static readonly Color DarkDisabledText = Color.FromArgb(140, 140, 140);
       private static readonly Color DarkText = Color.Gainsboro;
+      private static readonly Color DarkImageMargin = Color.FromArgb(38, 38, 38);
 
       public static ThemeMode GetUserThemeMode()
       {
@@ -104,12 +108,14 @@ namespace Synthesia
          {
             menuStrip.BackColor = DarkSurface;
             menuStrip.ForeColor = DarkText;
+            menuStrip.Renderer = new ToolStripProfessionalRenderer(new DarkColorTable());
             ApplyDarkThemeToToolStripItems(menuStrip.Items);
          }
          else if (control is ToolStrip toolStrip)
          {
             toolStrip.BackColor = DarkSurface;
             toolStrip.ForeColor = DarkText;
+            toolStrip.Renderer = new ToolStripProfessionalRenderer(new DarkColorTable());
             ApplyDarkThemeToToolStripItems(toolStrip.Items);
          }
          else if (control is TextBoxBase || control is ComboBox || control is ListBox)
@@ -167,12 +173,14 @@ namespace Synthesia
          {
             menuStrip.BackColor = SystemColors.Control;
             menuStrip.ForeColor = SystemColors.ControlText;
+            menuStrip.Renderer = null;
             ApplyLightThemeToToolStripItems(menuStrip.Items);
          }
          else if (control is ToolStrip toolStrip)
          {
             toolStrip.BackColor = SystemColors.Control;
             toolStrip.ForeColor = SystemColors.ControlText;
+            toolStrip.Renderer = null;
             ApplyLightThemeToToolStripItems(toolStrip.Items);
          }
          else if (control is TextBoxBase || control is ComboBox || control is ListBox)
@@ -217,11 +225,12 @@ namespace Synthesia
       {
          foreach (ToolStripItem item in items)
          {
-            item.ForeColor = DarkText;
+            item.ForeColor = item.Enabled ? DarkText : DarkDisabledText;
             if (item is ToolStripDropDownItem dropDownItem && dropDownItem.DropDown is ToolStripDropDownMenu menu)
             {
                menu.BackColor = DarkSurface;
                menu.ForeColor = DarkText;
+               menu.Renderer = new ToolStripProfessionalRenderer(new DarkColorTable());
                ApplyDarkThemeToToolStripItems(dropDownItem.DropDownItems);
             }
          }
@@ -236,9 +245,32 @@ namespace Synthesia
             {
                menu.BackColor = SystemColors.Control;
                menu.ForeColor = SystemColors.ControlText;
+               menu.Renderer = null;
                ApplyLightThemeToToolStripItems(dropDownItem.DropDownItems);
             }
          }
+      }
+
+      private sealed class DarkColorTable : ProfessionalColorTable
+      {
+         public override Color ToolStripBorder => DarkBorder;
+         public override Color MenuBorder => DarkBorder;
+         public override Color MenuItemBorder => DarkBorder;
+         public override Color MenuItemSelected => DarkHover;
+         public override Color MenuItemSelectedGradientBegin => DarkHover;
+         public override Color MenuItemSelectedGradientEnd => DarkHover;
+         public override Color MenuItemPressedGradientBegin => DarkPressed;
+         public override Color MenuItemPressedGradientMiddle => DarkPressed;
+         public override Color MenuItemPressedGradientEnd => DarkPressed;
+         public override Color ToolStripDropDownBackground => DarkBackground;
+         public override Color ImageMarginGradientBegin => DarkImageMargin;
+         public override Color ImageMarginGradientMiddle => DarkImageMargin;
+         public override Color ImageMarginGradientEnd => DarkImageMargin;
+         public override Color SeparatorDark => DarkBorder;
+         public override Color SeparatorLight => DarkBorder;
+         public override Color ToolStripGradientBegin => DarkSurface;
+         public override Color ToolStripGradientMiddle => DarkSurface;
+         public override Color ToolStripGradientEnd => DarkSurface;
       }
    }
 }

--- a/win-gui/ThemeManager.cs
+++ b/win-gui/ThemeManager.cs
@@ -23,6 +23,7 @@ namespace Synthesia
       private static readonly Color DarkDisabledText = Color.FromArgb(140, 140, 140);
       private static readonly Color DarkText = Color.Gainsboro;
       private static readonly Color DarkImageMargin = Color.FromArgb(38, 38, 38);
+      private static readonly Color DarkInputBorder = Color.FromArgb(120, 120, 120);
 
       public static ThemeMode GetUserThemeMode()
       {
@@ -130,7 +131,19 @@ namespace Synthesia
             toolStrip.Renderer = new ToolStripProfessionalRenderer(new DarkColorTable());
             ApplyDarkThemeToToolStripItems(toolStrip.Items);
          }
-         else if (control is TextBoxBase || control is ComboBox || control is ListBox)
+         else if (control is TextBoxBase textBox)
+         {
+            control.BackColor = DarkBackground;
+            control.ForeColor = DarkText;
+            EnsureBorderWrapper(textBox, DarkInputBorder);
+         }
+         else if (control is ListBox listBox)
+         {
+            control.BackColor = DarkBackground;
+            control.ForeColor = DarkText;
+            EnsureBorderWrapper(listBox, DarkInputBorder);
+         }
+         else if (control is ComboBox)
          {
             control.BackColor = DarkBackground;
             control.ForeColor = DarkText;
@@ -147,10 +160,13 @@ namespace Synthesia
          }
          else if (control is Button button)
          {
+            button.UseVisualStyleBackColor = false;
             button.BackColor = DarkSurface;
-            button.ForeColor = DarkText;
+            button.ForeColor = button.Enabled ? DarkText : DarkDisabledText;
             button.FlatStyle = FlatStyle.Flat;
             button.FlatAppearance.BorderColor = DarkBorder;
+            button.FlatAppearance.MouseOverBackColor = DarkHover;
+            button.FlatAppearance.MouseDownBackColor = DarkPressed;
          }
          else if (control is Label || control is CheckBox || control is RadioButton)
          {
@@ -195,7 +211,19 @@ namespace Synthesia
             toolStrip.Renderer = null;
             ApplyLightThemeToToolStripItems(toolStrip.Items);
          }
-         else if (control is TextBoxBase || control is ComboBox || control is ListBox)
+         else if (control is TextBoxBase textBox)
+         {
+            control.BackColor = SystemColors.Window;
+            control.ForeColor = SystemColors.WindowText;
+            EnsureDefaultBorder(textBox);
+         }
+         else if (control is ListBox listBox)
+         {
+            control.BackColor = SystemColors.Window;
+            control.ForeColor = SystemColors.WindowText;
+            EnsureDefaultBorder(listBox);
+         }
+         else if (control is ComboBox)
          {
             control.BackColor = SystemColors.Window;
             control.ForeColor = SystemColors.WindowText;
@@ -283,6 +311,158 @@ namespace Synthesia
          public override Color ToolStripGradientBegin => DarkSurface;
          public override Color ToolStripGradientMiddle => DarkSurface;
          public override Color ToolStripGradientEnd => DarkSurface;
+      }
+
+      private sealed class BorderWrapState
+      {
+         public Control Control { get; }
+         public Control Parent { get; }
+         public int ChildIndex { get; }
+         public DockStyle Dock { get; }
+         public AnchorStyles Anchor { get; }
+         public Point Location { get; }
+         public Size Size { get; }
+         public Padding Margin { get; }
+         public BorderStyle BorderStyle { get; }
+
+         public BorderWrapState(Control control, Control parent)
+         {
+            Control = control;
+            Parent = parent;
+            ChildIndex = parent.Controls.GetChildIndex(control);
+            Dock = control.Dock;
+            Anchor = control.Anchor;
+            Location = control.Location;
+            Size = control.Size;
+            Margin = control.Margin;
+            if (control is TextBoxBase textBox)
+            {
+               BorderStyle = textBox.BorderStyle;
+            }
+            else if (control is ListBox listBox)
+            {
+               BorderStyle = listBox.BorderStyle;
+            }
+            else
+            {
+               BorderStyle = BorderStyle.Fixed3D;
+            }
+         }
+      }
+
+      private static void EnsureBorderWrapper(Control control, Color borderColor)
+      {
+         if (control.Parent is BorderPanel panel && panel.Tag is BorderWrapState)
+         {
+            panel.BorderColor = borderColor;
+            return;
+         }
+
+         if (control.Parent == null) return;
+
+         Control parent = control.Parent;
+         var state = new BorderWrapState(control, parent);
+         var wrapper = new BorderPanel
+         {
+            BackColor = DarkBackground,
+            BorderColor = borderColor,
+            Margin = control.Margin,
+            Tag = state,
+            TabStop = false
+         };
+
+         if (control.Dock != DockStyle.None)
+         {
+            wrapper.Dock = control.Dock;
+         }
+         else
+         {
+            wrapper.Anchor = control.Anchor;
+            wrapper.Location = control.Location;
+            wrapper.Size = control.Size;
+         }
+
+         parent.Controls.Add(wrapper);
+         parent.Controls.SetChildIndex(wrapper, state.ChildIndex);
+
+         if (control is TextBoxBase textBox)
+         {
+            textBox.BorderStyle = BorderStyle.None;
+         }
+         else if (control is ListBox listBox)
+         {
+            listBox.BorderStyle = BorderStyle.None;
+         }
+
+         control.Margin = Padding.Empty;
+         control.Dock = DockStyle.None;
+         wrapper.Controls.Add(control);
+         wrapper.LayoutChild();
+      }
+
+      private static void EnsureDefaultBorder(Control control)
+      {
+         if (control.Parent is BorderPanel panel && panel.Tag is BorderWrapState state)
+         {
+            Control parent = state.Parent;
+            if (parent == null) return;
+
+            panel.Controls.Remove(control);
+            parent.Controls.Add(control);
+            parent.Controls.SetChildIndex(control, state.ChildIndex);
+
+            control.Dock = state.Dock;
+            control.Anchor = state.Anchor;
+            control.Location = state.Location;
+            control.Size = state.Size;
+            control.Margin = state.Margin;
+            if (control is TextBoxBase textBox)
+            {
+               textBox.BorderStyle = state.BorderStyle;
+            }
+            else if (control is ListBox listBox)
+            {
+               listBox.BorderStyle = state.BorderStyle;
+            }
+
+            panel.Dispose();
+         }
+      }
+
+      private sealed class BorderPanel : Panel
+      {
+         [System.ComponentModel.Browsable(false)]
+         [System.ComponentModel.DesignerSerializationVisibility(System.ComponentModel.DesignerSerializationVisibility.Hidden)]
+         public Color BorderColor { get; set; } = DarkInputBorder;
+
+         public BorderPanel()
+         {
+            SetStyle(ControlStyles.AllPaintingInWmPaint | ControlStyles.OptimizedDoubleBuffer | ControlStyles.UserPaint, true);
+         }
+
+         protected override void OnPaint(PaintEventArgs e)
+         {
+            base.OnPaint(e);
+            using (var pen = new Pen(BorderColor))
+            {
+               var rect = new Rectangle(0, 0, Width - 1, Height - 1);
+               e.Graphics.DrawRectangle(pen, rect);
+            }
+         }
+
+         protected override void OnLayout(LayoutEventArgs levent)
+         {
+            base.OnLayout(levent);
+            LayoutChild();
+         }
+
+         public void LayoutChild()
+         {
+            if (Controls.Count == 0) return;
+            Control child = Controls[0];
+            child.Location = new Point(1, 1);
+            child.Size = new Size(Math.Max(0, Width - 2), Math.Max(0, Height - 2));
+         }
       }
    }
 }


### PR DESCRIPTION
> [!CAUTION]
> Developed on a fork with dotnet 10 tooling: [ahkrichards/feature/dotnet-10](https://github.com/ahkrichards/metadata-editor/tree/feature/dotnet-10)
>
> Not tested against .NET 4.8 toolchain.
>
> If there is interest in this feature, I can invest more time to adding for Mac as well as ensuring compatibility with .NET 4.8. I simply added dotnet 10 toolchain for the purposes of quick starting my local development without need to add augment my env with explicit .NET 4.8 support.

This PR adds a dark mode spike for the Windows GUI, including theme switching, improved contrast, and Windows title bar integration. The UI now supports Follow System / Light / Dark modes, with consistent styling across menus, inputs, and dialogs.

# Key Changes

- Added a theme manager and persisted theme setting (Follow System / Light / Dark).
- Applied dark theme styling across the WinForms UI and dialogs.
- Improved menu contrast (including left margin) to match legacy readability.
- Fixed initial text color application before controls become enabled.
- Tuned input/list borders and button contrast for dark mode.
- Applied Windows title bar dark mode when supported (safe fallback on unsupported OS).

# Notes

- Title bar theming uses DWM attributes on Windows 10/11; no-op fallback on older systems.
- mac GUI intentionally untouched.

# Preview

Initial load:

<img width="844" height="794" alt="image" src="https://github.com/user-attachments/assets/9d2bbd95-8898-479e-890e-095545f8519a" />

New `View` menu and `Theme` menu items:

<img width="471" height="195" alt="image" src="https://github.com/user-attachments/assets/52a5005d-a884-4876-96e5-9e666a19d163" />

Loaded song:

<img width="843" height="233" alt="image" src="https://github.com/user-attachments/assets/4e569167-b7b0-4fee-95a6-524f5b0be7ab" />

Backwards compatible / maintains previous theme:

<img width="844" height="794" alt="image" src="https://github.com/user-attachments/assets/8fdf7e7e-75e0-42a1-8dff-042d4c8c1b94" />
